### PR TITLE
Update README.md: adjust docx parsing logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ func main() {
 	fmt.Println("Plain text:")
 	for _, it := range doc.Document.Body.Items {
 		switch it.(type) {
-		case *docx.Paragraph, *docx.WTable: // printable
+		case *docx.Paragraph, *docx.Table: // printable
 			fmt.Println(it)
 		}
 	}


### PR DESCRIPTION
Solve the problem that the readme demo doesn't work because `WTable` has been changed to `Table`